### PR TITLE
Verify code functionality

### DIFF
--- a/dcrc_allcitizenservices/DCRC_AllCitizenServices/DCRC_AllCitizenServices-dataservice-parent/DCRC_AllCitizenServices-dataservice/pom.xml
+++ b/dcrc_allcitizenservices/DCRC_AllCitizenServices/DCRC_AllCitizenServices-dataservice-parent/DCRC_AllCitizenServices-dataservice/pom.xml
@@ -24,7 +24,7 @@
         <checksumPolicy>ignore</checksumPolicy>
       </releases>
       <id>wso2-nexus</id>
-      <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+      <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
@@ -34,7 +34,7 @@
         <checksumPolicy>ignore</checksumPolicy>
       </releases>
       <id>wso2-nexus</id>
-      <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+      <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
     </pluginRepository>
   </pluginRepositories>
   <build>

--- a/dcrc_allcitizenservices/DCRC_AllCitizenServices/pom.xml
+++ b/dcrc_allcitizenservices/DCRC_AllCitizenServices/pom.xml
@@ -13,6 +13,34 @@
     <module>DCRC_AllCitizenServices-registryresources-parent</module>
     <module>DCRC_AllCitizenServices-synapse-artifacts-parent</module>
   </modules>
+  <repositories>
+    <repository>
+      <releases>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>ignore</checksumPolicy>
+      </releases>
+      <id>wso2-nexus</id>
+      <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+    </repository>
+    <repository>
+      <id>wso2-maven2-repository</id>
+      <url>https://dist.wso2.org/maven2</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>ignore</checksumPolicy>
+      </releases>
+      <id>wso2-nexus</id>
+      <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>wso2-maven2-repository</id>
+      <url>https://dist.wso2.org/maven2</url>
+    </pluginRepository>
+  </pluginRepositories>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Add WSO2 Maven repositories to the parent POM and update existing repository URLs to HTTPS to resolve build failures.

The project's Maven build was failing due to missing WSO2-specific plugins and the `maven-default-http-blocker` preventing access to HTTP repositories. This PR adds the necessary WSO2 repositories to the main parent POM and updates all WSO2 repository URLs to use HTTPS, allowing Maven to resolve and download the required plugins.

---
<a href="https://cursor.com/background-agent?bcId=bc-34e16aa0-c81f-41df-9a68-6c69b1c9d566">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34e16aa0-c81f-41df-9a68-6c69b1c9d566">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

